### PR TITLE
Don't ignore unused args

### DIFF
--- a/resource/train.R
+++ b/resource/train.R
@@ -133,7 +133,7 @@ TrainForecastingModels <- function(ts, df, xreg = NULL, modelParameterList,
       .fcn = modelParameters[["modelFunction"]],
       y = ts,
       args = modelParameters[["kwargs"]],
-      .ignoreUnusedArgs = TRUE
+      .ignoreUnusedArgs = FALSE
     )
     endTime = Sys.time()
     PrintPlugin(paste0(modelName," training completed after ",


### PR DESCRIPTION
Changed .ignoreUnusedArgs to FALSE to have parameters passed to "...".
E.g. nnetar() passes everything not defined in its head to nnet(). With this change defining an unknown custom parameter in the plugin's model advanced settings will cause an error (previous behaviour was to ignore which made debugging complicated).